### PR TITLE
Don't flush only if file handle is closed

### DIFF
--- a/rom/dos/runcommand.c
+++ b/rom/dos/runcommand.c
@@ -162,8 +162,11 @@
      * NOTE: AmigaOS 3.1's C:Execute closes Input(),
      *       so we need to catch that here.
      */
-    if (Cli() && Cli()->cli_CurrentInput == Input()) {
-        Flush(Input());
+    if (Input())
+    {
+        struct FileHandle *in = (struct FileHandle *)BADDR(Input());
+        if (in->fh_Func3 != -1)
+            Flush(Input());
     }
 
     FreeMem(stack,stacksize);


### PR DESCRIPTION
This matches directly the comment. Previous implemetation
was not flushing when Input() was different than cli_CurrentInput
which is the case when running script. This caused the arguments
of the last command in script to be re-emited as another command.
This was not visible for shell commands as they ReadArg the Input()