### PR TITLE
Add mkapollo.sh

### DIFF
--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -66,25 +66,25 @@ defaults () {
 }
 
 deposit-rom () {
-	if [ -e $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf ]; then
-		cp $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf $WORK/
-		print_bold_nl "${ARROWS} ADF RESULT: $(du --apparent-size -h $WORK/bootdisk-amiga-m68k.adf)"
-	fi
+		 if [ -e $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf ]; then
+                  cp $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf $WORK/
+                  print_bold_nl "${ARROWS} ADF RESULT: $(du --apparent-size -h $WORK/bootdisk-amiga-m68k.adf)"
+                 fi
 
-	if [ -e $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin ]; then
-		cat $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin >$WORK/AROS.ROM
-		echo "${ARROWS} ROM RESULT: $(du --apparent-size -h $WORK/AROS.ROM)"
-	fi
+		 if [ -e $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin ]; then
+                  cat $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin >$WORK/AROS.ROM
+                  echo "${ARROWS} ROM RESULT: $(du --apparent-size -h $WORK/AROS.ROM)"
+                 fi
 
-	if [ -e $BIN/distfiles/aros-amiga-m68k.iso ]; then
-		cp $BIN/distfiles/aros-amiga-m68k.iso $WORK/
-		echo "${ARROWS} ISO RESULT: $(du --apparent-size -h $WORK/aros-amiga-m68k.iso)"
-	fi
+		 if [ -e $BIN/distfiles/aros-amiga-m68k.iso ]; then
+                  cp $BIN/distfiles/aros-amiga-m68k.iso $WORK/
+                  echo "${ARROWS} ISO RESULT: $(du --apparent-size -h $WORK/aros-amiga-m68k.iso)"
+                 fi
 
-	if [ -e $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device ]; then
-		cp $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device $WORK/
-		echo "${ARROWS} SD0 RESULT: $(du --apparent-size -h $WORK/sagasd.device)"
-	fi
+		 if [ -e $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device ]; then
+                  cp $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device $WORK/
+                  echo "${ARROWS} SD0 RESULT: $(du --apparent-size -h $WORK/sagasd.device)"
+                 fi
 }
 
 check-deps () {

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -87,22 +87,6 @@ deposit-rom () {
                  fi
 }
 
-check-deps () {
-	if [ ${CONF} = 1 ] || [ ! -e "${BIN}/config.status" ];	then configure;			fi
-	if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ];			then compile mmake;	fi
-	if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ];				then compile sfdc;	fi
-}
-
-print_bold () {
-	# shellcheck disable=SC2059
-	printf "${BOLD}${1}${BOLDEND}"
-}
-
-print_bold_nl () {
-	# shellcheck disable=SC2059
-	print_bold "${1}\n"
-}
-
 makeclean () { cd "${BIN}" || exit; make clean; cd "${DIR}" || exit; }
 gitclean  () { cd "${SRC}" || exit; git clean -df; cd "${DIR}" || exit; }
 pkgcheck  () { if [ $(dpkg-query -W -f '${Binary:Package} ${Status}\n' $PKGS | wc -l) -eq $(echo $PKGS | wc -w) ]; then return 0; else return 1; fi; }
@@ -304,6 +288,22 @@ cat << EOF
 EOF
 printf "%s\n\n" "$(defaults)"
 print_bold_nl "Please Amiga responsibly."
+}
+
+check-deps () {
+	if [ ${CONF} = 1 ] || [ ! -e "${BIN}/config.status" ];	then configure;			fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ];			then compile mmake;	fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ];				then compile sfdc;	fi
+}
+
+print_bold () {
+	# shellcheck disable=SC2059
+	printf "${BOLD}${1}${BOLDEND}"
+}
+
+print_bold_nl () {
+	# shellcheck disable=SC2059
+	print_bold "${1}\n"
 }
 ## END FUNCTIONS ##
 

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -60,9 +60,9 @@ freevars () { unset CONFOPTS MAKEOPTS SRC PORTS BIN DIR BRANCH CLEAN DL CONF CON
 
 ## BEGIN FUNCTIONS ##
 defaults () {
-	echo -n "--branch=${BRANCH} -c${CLEAN} -d${DL} -f${CONF} -g${GITCLEAN} --jobs=${JOBS} -v${VAMP} "
-	if [ $REZ = "640x200x4" ]; then echo -n "-n"; else echo -n "-p"; fi
-	echo " --work=${WORK} --conf=\"${CONFO}\" --make=\"${MAKEO}\" --cpu=${CPU} --fpu=${FPU} --opt=${OPT}"
+              echo -n "--branch=${BRANCH} -c${CLEAN} -d${DL} -f${CONF} -g${GITCLEAN} --jobs=${JOBS} -v${VAMP} "
+              if [ $REZ = "640x200x4" ]; then echo -n "-n"; else echo -n "-p"; fi
+              echo " --work=${WORK} --conf=\"${CONFO}\" --make=\"${MAKEO}\" --cpu=${CPU} --fpu=${FPU} --opt=${OPT}"
 }
 
 deposit-rom () {

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -37,7 +37,6 @@ NC="$(tput sgr0)"
 ARROWS="${BOLD}${YELLOW}>>>${NC}"
 ## BEGIN Beauty Variables ##
 
-
 ## BEGIN Variables ##
 setvars () {
 	DIR="$(pwd)"
@@ -66,22 +65,6 @@ defaults () {
 	echo " --work=${WORK} --conf=\"${CONFO}\" --make=\"${MAKEO}\" --cpu=${CPU} --fpu=${FPU} --opt=${OPT}"
 }
 
-check-deps () {
-	if [ ${CONF} = 1 ] || [ ! -e "${BIN}/config.status" ];	then configure;			fi
-	if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ];			then compile mmake;	fi
-	if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ];				then compile sfdc;	fi
-}
-
-print_bold () {
-	# shellcheck disable=SC2059
-	printf "${BOLD}${1}${BOLDEND}"
-}
-
-print_bold_nl () {
-	# shellcheck disable=SC2059
-	print_bold "${1}\n"
-}
-
 deposit-rom () {
 	if [ -e $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf ]; then
 		cp $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf $WORK/
@@ -102,6 +85,22 @@ deposit-rom () {
 		cp $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device $WORK/
 		echo "${ARROWS} SD0 RESULT: $(du --apparent-size -h $WORK/sagasd.device)"
 	fi
+}
+
+check-deps () {
+	if [ ${CONF} = 1 ] || [ ! -e "${BIN}/config.status" ];	then configure;			fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ];			then compile mmake;	fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ];				then compile sfdc;	fi
+}
+
+print_bold () {
+	# shellcheck disable=SC2059
+	printf "${BOLD}${1}${BOLDEND}"
+}
+
+print_bold_nl () {
+	# shellcheck disable=SC2059
+	print_bold "${1}\n"
 }
 
 makeclean () { cd "${BIN}" || exit; make clean; cd "${DIR}" || exit; }

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -56,6 +56,10 @@ deposit-rom () {
                   cp $BIN/distfiles/aros-amiga-m68k.iso $WORK/
                   echo ">>> ISO RESULT: $(du --apparent-size -h $WORK/aros-amiga-m68k.iso)"
                  fi
+		 if [ -e $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device ]; then
+                  cp $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device $WORK/
+                  echo ">>> SD0 RESULT: $(du --apparent-size -h $WORK/sagasd.device)"
+                 fi
 }
 makeclean () { cd $BIN; make clean; cd $DIR; }
 gitclean () { cd $SRC; git clean -df; cd $DIR; }
@@ -310,6 +314,9 @@ case $CMD in
    mv $PORTS/linux* $BIN/bin/
   fi
   echo ">>> Done.  You may now redownload or even choose another branch."
+ ;;
+ deposit-rom)
+  deposit-rom
  ;;
  *)
   help

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -74,7 +74,7 @@ deposit-rom () {
 		 if [ -e $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin ]; then
                   cat $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin >$WORK/AROS.ROM
                   print_bold "${ARROWS} ${BOLD}${GREEN}ROM RESULT:${NC} "
-                  read -r ROMSIZE ROMSIZETYPE ROMFILEPATH <<<$(du --apparent-size -h apollo-os/AROS.ROM |sed -re "s|([0-9\.]+)([a-Z])\t([-/a-Z\.]+)|\1 \2 \3|g")
+                  read -r ROMSIZE ROMSIZETYPE ROMFILEPATH <<< "$(du --apparent-size -h apollo-os/AROS.ROM |sed -re "s|([0-9\.]+)([a-Z])\t([-/a-Z\.]+)|\1 \2 \3|g")"
 
                   # shellcheck disable=SC2072
                   MAXROMSIZE=1.0
@@ -365,7 +365,13 @@ case $CMD in
   if [ ! -e "${WORK}/AROS.ROM" ]; then compile kernel; fi
   print_bold_nl ""
   print_bold_nl "${YELLOW} ---- ${GREEN}Start ROM Contents: ${YELLOW}----${NC}"
-  strings "${WORK}/AROS.ROM" | grep "\$VER" | sed "s/i\$VER: //g" | sed "s/\$VER: //g" | sed "s/i\$VER://g" | sed "s/\$VER://g"
+  #strings "${WORK}/AROS.ROM" | grep "\$VER" | sed "s/i\$VER: //g" | sed "s/\$VER: //g" | sed "s/i\$VER://g" | sed "s/\$VER://g"
+  readarray a <<< $(strings "${WORK}/AROS.ROM" | grep "\$VER" | sed -re 's|.*\$VER\:\s*([\.\-\_a-Z0-9]+)\s*([-a-Z0-9\_]*)\s([\.0-9]+)\s([0-9\(\)\.]+)(.*)|\1 \"\2\" \3 \4|g')
+
+  for element in "${a[@]}"; do
+   readarray -td ' ' b  <<< "$(printf "%s" "${element}"| tr -d "\n")"; printf "${BOLD}${YELLOW}%s${NC} %s %s\n" ${b[0]} ${b[2]} ${b[3]};
+  done
+
   print_bold_nl "${YELLOW} ----- ${GREEN}End ROM Contents: ${YELLOW}-----${NC}"
   print_bold_nl ""
  ;;

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -25,7 +25,7 @@ EXCLUDE=0
 ## BEGIN Variables ##
 setvars () {
  DIR="$(pwd)"
- SRC="$DIR/$WORK/src"
+ SRC="$DIR/"
  PORTS="$DIR/$WORK/prt"
  BIN="$DIR/$WORK/bin"
  CONFOPTS="--target=amiga-m68k --with-optimization=-O$OPT --with-aros-prefs=classic --with-resolution=$REZ --with-cpu=$CPU --with-fpu=$FPU --disable-mmu --with-portssources=$PORTS"
@@ -287,16 +287,18 @@ if [ $CLEAN = 1 ]; 	         then echo ">>> Fresh build requested, cleaning.";	m
 
 case $CMD in
  dist)
-  if [ $CONF = 1 ] || [ ! -e $BIN/config.status ]; then configure; fi
+  if [ $CONF = 1 ] || [ ! -e "${BIN}/config.status" ]; then configure; fi
   compile distfiles
  ;;
  kernel)
-  if [ $CONF = 1 ] || [ ! -e $BIN/config.status ]; then configure; fi
+  if [ $CONF = 1 ] || [ ! -e "${BIN}/config.status" ]; then configure; fi
   compile kernel
   deposit-rom
  ;;
  all)
   configure
+  if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ]; then compile mmake; fi
+  if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ]; then compile sfdc; fi
   compile distfiles
   deposit-rom
  ;;

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -7,9 +7,14 @@ CLEAN=0
 GITCLEAN=0
 DL=0
 WORK="apollo-os"
-BRANCH="$(git branch --show-current)"
-REMOTE=$(git status -sb | sed "s/\#\#\ ${BRANCH}\.\.\.//g" | sed "s/\/${BRANCH}//g" | head -n 1)
-REPO="$(git remote get-url ${REMOTE})"
+if [ -e ".git" ]; then
+	BRANCH="$(git branch --show-current)"
+	REMOTE=$(git status -sb | sed "s/\#\#\ ${BRANCH}\.\.\.//g" | sed "s/\/${BRANCH}//g" | head -n 1)
+	REPO="$(git remote get-url ${REMOTE})"
+else
+	REPO="https://github.com/ApolloTeam-dev/AROS"
+	BRANCH="v4-alynna"
+fi
 REZ=640x256x4
 CPU=68040
 FPU=68881
@@ -22,38 +27,54 @@ MAKEO=""
 EXCLUDE=0
 ## END Configuration ##
 
+## BEGIN Beauty Variables ##
+BOLD="$(tput bold)"
+BOLDEND="$(tput sgr0)"
+RED="$(tput setaf 1)"
+GREEN="$(tput setaf 2)"
+YELLOW="$(tput setaf 3)"
+NC="$(tput sgr0)"
+ARROWS="${BOLD}${YELLOW}>>>${NC}"
+## BEGIN Beauty Variables ##
+
+
 ## BEGIN Variables ##
 setvars () {
- DIR="$(pwd)"
- SRC="$DIR/"
- PORTS="$DIR/$WORK/prt"
- BIN="$DIR/$WORK/bin"
- CONFOPTS="--target=amiga-m68k --with-optimization=-O$OPT --with-aros-prefs=classic --with-resolution=$REZ --with-cpu=$CPU --with-fpu=$FPU --disable-mmu --with-portssources=$PORTS"
- if [ $VAMP = 0 ]; then CONFOPTS="$CONFOPTS --with-nonvampire-support"; fi
- if [ $DEBUG = 1 ]; then CONFOPTS="$CONFOPTS --enable-debug --with-serial-debug"; fi
- MAKEOPTS="-j$JOBS"
- PKGS="git gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python-mako libxcursor-dev gcc-multilib"
- export CONFOPTS MAKEOPTS SRC PORTS BIN DIR PKGS
+	DIR="$(pwd)"
+	if [ -e "${DIR}/.git" ]; then
+		SRC="${DIR}/"
+	else
+		SRC="${DIR}/${WORK}/src"
+	fi
+	PORTS="${DIR}/${WORK}/prt"
+	BIN="${DIR}/${WORK}/bin"
+	CONFOPTS="--target=amiga-m68k --with-optimization=-O${OPT} --with-aros-prefs=classic --with-resolution=${REZ} --with-cpu=${CPU} --with-fpu=${FPU} --disable-mmu --with-portssources=${PORTS}"
+	if [ ${VAMP} = 0 ];		then CONFOPTS="${CONFOPTS} --with-nonvampire-support"; fi
+	if [ ${DEBUG} = 1 ];	then CONFOPTS="${CONFOPTS} --enable-debug --with-serial-debug"; fi
+	MAKEOPTS="-j${JOBS}"
+	PKGS="git gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python-mako libxcursor-dev gcc-multilib"
+	export CONFOPTS MAKEOPTS SRC PORTS BIN DIR PKGS
 }
+
 freevars () { unset CONFOPTS MAKEOPTS SRC PORTS BIN DIR BRANCH CLEAN DL CONF CONFO GITCLEAN JOBS MAKEO REZ VAMP WORK DEBUG CPU FPU OPT; }
 ## END Variables ##
 
 ## BEGIN FUNCTIONS ##
 defaults () {
-              echo -n "--branch=$BRANCH -c$CLEAN -d$DL -f$CONF -g$GITCLEAN --jobs=$JOBS -v$VAMP "
-              if [ $REZ = "640x200x4" ]; then echo -n "-n"; else echo -n "-p"; fi
-              echo " --work=$WORK --conf=\"$CONFO\" --make=\"$MAKEO\" --cpu=$CPU --fpu=$FPU --opt=$OPT"
+	echo -n "--branch=${BRANCH} -c${CLEAN} -d${DL} -f${CONF} -g${GITCLEAN} --jobs=${JOBS} -v${VAMP} "
+	if [ $REZ = "640x200x4" ]; then echo -n "-n"; else echo -n "-p"; fi
+	echo " --work=${WORK} --conf=\"${CONFO}\" --make=\"${MAKEO}\" --cpu=${CPU} --fpu=${FPU} --opt=${OPT}"
 }
 
 check-deps () {
-	if [ $CONF = 1 ] || [ ! -e "${BIN}/config.status" ]; then configure; fi
-  if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ]; then compile mmake; fi
-  if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ]; then compile sfdc; fi
+	if [ ${CONF} = 1 ] || [ ! -e "${BIN}/config.status" ];	then configure;			fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ];			then compile mmake;	fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ];				then compile sfdc;	fi
 }
 
 print_bold () {
 	# shellcheck disable=SC2059
-	printf "\033[1m${1}\033[0m"
+	printf "${BOLD}${1}${BOLDEND}"
 }
 
 print_bold_nl () {
@@ -62,37 +83,41 @@ print_bold_nl () {
 }
 
 deposit-rom () {
-		 if [ -e $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf ]; then
-                  cp $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf $WORK/
-                  echo ">>> ADF RESULT: $(du --apparent-size -h $WORK/bootdisk-amiga-m68k.adf)"
-                 fi
-		 if [ -e $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin ]; then
-                  cat $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin >$WORK/AROS.ROM
-                  echo ">>> ROM RESULT: $(du --apparent-size -h $WORK/AROS.ROM)"
-                 fi
-		 if [ -e $BIN/distfiles/aros-amiga-m68k.iso ]; then
-                  cp $BIN/distfiles/aros-amiga-m68k.iso $WORK/
-                  echo ">>> ISO RESULT: $(du --apparent-size -h $WORK/aros-amiga-m68k.iso)"
-                 fi
-		 if [ -e $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device ]; then
-                  cp $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device $WORK/
-                  echo ">>> SD0 RESULT: $(du --apparent-size -h $WORK/sagasd.device)"
-                 fi
+	if [ -e $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf ]; then
+		cp $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf $WORK/
+		print_bold_nl "${ARROWS} ADF RESULT: $(du --apparent-size -h $WORK/bootdisk-amiga-m68k.adf)"
+	fi
+
+	if [ -e $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin ]; then
+		cat $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin >$WORK/AROS.ROM
+		echo "${ARROWS} ROM RESULT: $(du --apparent-size -h $WORK/AROS.ROM)"
+	fi
+
+	if [ -e $BIN/distfiles/aros-amiga-m68k.iso ]; then
+		cp $BIN/distfiles/aros-amiga-m68k.iso $WORK/
+		echo "${ARROWS} ISO RESULT: $(du --apparent-size -h $WORK/aros-amiga-m68k.iso)"
+	fi
+
+	if [ -e $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device ]; then
+		cp $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device $WORK/
+		echo "${ARROWS} SD0 RESULT: $(du --apparent-size -h $WORK/sagasd.device)"
+	fi
 }
-makeclean () { cd $BIN; make clean; cd $DIR; }
-gitclean () { cd $SRC; git clean -df; cd $DIR; }
-pkgcheck () { if [ $(dpkg-query -W -f '${Binary:Package} ${Status}\n' $PKGS | wc -l) -eq $(echo $PKGS | wc -w) ]; then return 0; else return 1; fi; }
-download () { cd $WORK; if [ ! -d $SRC ]; then git clone --recursive $REPO --branch=$BRANCH $SRC; cd $DIR; fi }
-configure () { cd $BIN; $SRC/configure $CONFOPTS $CONFO; cd $DIR; }
-compile () { cd $BIN; make $1 $MAKEOPTS $MAKEO; cd $DIR; }
+
+makeclean () { cd "${BIN}" || exit; make clean; cd "${DIR}" || exit; }
+gitclean  () { cd "${SRC}" || exit; git clean -df; cd "${DIR}" || exit; }
+pkgcheck  () { if [ $(dpkg-query -W -f '${Binary:Package} ${Status}\n' $PKGS | wc -l) -eq $(echo $PKGS | wc -w) ]; then return 0; else return 1; fi; }
+download  () { cd "${WORK}" || exit; if [ ! -d $SRC ]; then git clone --recursive $REPO --branch=$BRANCH $SRC; cd $DIR; fi }
+configure () { cd "${BIN}" || exit; ${SRC}/configure $CONFOPTS $CONFO; cd $DIR; }
+compile   () { cd "${BIN}" || exit; make $1 $MAKEOPTS $MAKEO; cd $DIR; }
 
 valid-cpu () {
- if [ "$1" = "" ]; then
-  echo "68000 68010 68020 68030 68040 68060"
-  return 0
- else
-  if [ "$1" == "680[12346]0" ]; then return 1; else return 0; fi
- fi
+	if [ "$1" = "" ]; then
+		echo "68000 68010 68020 68030 68040 68060"
+		return 0
+	else
+		if [ "$1" == "680[12346]0" ]; then return 1; else return 0; fi
+	fi
 }
 
 valid-fpu () {
@@ -215,7 +240,7 @@ for i in "$@"; do
    shift
   ;;
   *)
-   if [ "$CMD" = "" ]; then CMD=$i; shift;
+   if [ "${CMD}" = "" ]; then CMD=${i}; shift;
    else (echo "!!! There seems to be an issue with your Options." >&2); shift; exit 2
    fi
  esac
@@ -225,22 +250,23 @@ done
 
 help () {
 cat << EOF
-mkapollo.sh -- Roll your own ApolloOS image and ROM
- (C) 2021 Alynna Trypnotk, License APL 1.1:
+${BOLD}mkapollo.sh -- Roll your own ApolloOS image and ROM${NC}
+ (C) 2021 Alynna Trypnotk, License APL 1.1 & (C) 2021 Marlon Beijer (marlon@amigadev.com), License APL 1.1:
  https://github.com/ApolloTeam-dev/AROS/blob/master-new/LICENSE
 
  It does what NintenDon't.
- Syntax: mkapollo.sh [options] <command> [args]
+ ${BOLD}Syntax:${NC} mkapollo.sh [options] <command> [args]
 
- Commands:
+ ${BOLD}Commands:${NC}
   all                         Run configure, make distfiles and ROM (Start here!)
   dist                        Just make distfiles
   kernel                      Just make ROM
-  list-rom-contents						List the contents of the built rom
+  deposit-rom                 List paths to built files
+  list-rom-contents           List the contents of the built rom
   wipe                        Starts from near fresh (leaves ports)
   null                        Just parse options
 
- Options:
+ ${BOLD}Options:${NC}
   -b,--branch=<branch>        Select different branch
   -c,--clean                  Make clean first
   -d,--download               Delete source and redownload
@@ -269,47 +295,50 @@ echo "  Valid CPUs               : $(valid-cpu)"
 echo "  Valid FPUs               : $(valid-fpu)"
 cat << EOF
 
- It will automatically install the packages needed for Vampire Goodness.
+ It will automatically install the packages needed for Vampire Goodness,
+ assuming that you use a Debian based distribution.
  Note that sources will be downloaded if it is not found at the location.
  If you just want your ROM, just do:  mkapollo.sh all
  Then go get a coffee. Or a meal.
 
  The current defaults are:
 EOF
-echo "  $(defaults)"
-echo -e "\nPlease Amiga responsibly."
+printf "%s\n\n" "$(defaults)"
+print_bold_nl "Please Amiga responsibly."
 }
 ## END FUNCTIONS ##
 
 ## BEGIN MAIN ##
+# shellcheck disable=SC2068
 loop-through-opts $@
 if [ "$CMD" = "" ]; 	then help; exit 1; 	fi
 
 setvars
-print_bold "Making ApolloOS: "
+print_bold "${YELLOW}Making ApolloOS: "
 printf "%s %s\n" "${CMD}" "$(defaults)"
 
-print_bold "Configuration:   "
+print_bold "${YELLOW}Configuration:   "
 printf "%s\n" "${CONFOPTS}"
 
-print_bold "Make options:    "
+print_bold "${YELLOW}Make options:    "
 printf "%s\n" "${MAKEOPTS}"
 
-print_bold "Work directory:  "
+print_bold "${YELLOW}Work directory:  "
 printf "%s\n" "${WORK}"
 
-echo -n "3..."; sleep 1; echo -n "2..."; sleep 1; echo -n "1..."; sleep 1; print_bold_nl "Go!";
+print_bold "${YELLOW}Starting in:     "
+#echo -n "3..."; sleep 1; echo -n "2..."; sleep 1; echo -n "1..."; sleep 1; print_bold_nl "${GREEN}Go!";
 
 mkdir -p "${BIN}"
 
 if [ $(pkgcheck; echo $?) = 1 ]; then
- print_bold_nl ">>> You are missing required packages to build ApolloOS.  Attempting to install..."
+ print_bold_nl "${ARROWS} ${BOLD}${RED}You are missing required packages to build ApolloOS!  ${GREEN}Attempting to install...${NC}"
  apt -y update
  apt -y install "${PKGS}"
 fi
-if [ $DL = 1 ]; 	         then print_bold_nl ">>> Source wipe requested, deleting."; 	rm -rf $SRC; 	fi
-if [ ! -e $SRC ]; 	         then print_bold_nl ">>> Source not detected, downloading.";	download;	fi
-if [ $CLEAN = 1 ]; 	         then print_bold_nl ">>> Fresh build requested, cleaning.";	makeclean; 	fi
+if [ $DL = 1 ];                 then print_bold_nl "${ARROWS} Source wipe requested, ${RED}deleting${NC}.";     rm -rf "${SRC}"; fi
+if [ ! -e "${SRC}/configure" ]; then print_bold_nl "${ARROWS} Source not detected, ${GREEN}downloading${NC}.";  download;	       fi
+if [ $CLEAN = 1 ];              then print_bold_nl "${ARROWS} Fresh build requested, ${YELLOW}cleaning${NC}.";  makeclean;       fi
 
 case $CMD in
  dist)
@@ -325,9 +354,9 @@ case $CMD in
   check-deps
   if [ ! -e "${WORK}/AROS.ROM" ]; then compile kernel; fi
   print_bold_nl ""
-  print_bold_nl " ---- Start ROM Contents: ----"
+  print_bold_nl "${YELLOW} ---- ${GREEN}Start ROM Contents: ${YELLOW}----${NC}"
   strings "${WORK}/AROS.ROM" | grep "\$VER" | sed "s/i\$VER: //g" | sed "s/\$VER: //g" | sed "s/i\$VER://g" | sed "s/\$VER://g"
-  print_bold_nl " ----- End ROM Contents: -----"
+  print_bold_nl "${YELLOW} ----- ${GREEN}End ROM Contents: ${YELLOW}-----${NC}"
   print_bold_nl ""
  ;;
  all)
@@ -337,19 +366,19 @@ case $CMD in
  ;;
  wipe)
   print_bold_nl "!!! CTRL-AMIGA-AMIGA Pressed !!!"
-  print_bold_nl ">>> Removing sources"
+  print_bold_nl "${ARROWS} Removing sources"
   rm -rf $SRC
   if [ "$EXCLUDE" = "0" ]; then
-   print_bold_nl ">>> Preserving Crosstools (saves serious recompile time)"
+   print_bold_nl "${ARROWS} Preserving Crosstools (saves serious recompile time)"
    mv ${BIN}/bin/linux* ${PORTS}/
   fi
-  print_bold_nl ">>> Removing Binaries (Things in the work dir root are preserved)"
-  rm -rf $BIN
-  if [ "$EXCLUDE" = "0" ]; then
-   print_bold_nl ">>> Restoring Crosstools"
-   mv $PORTS/linux* $BIN/bin/
+  print_bold_nl "${ARROWS} Removing Binaries (Things in the work dir root are preserved)"
+  rm -rf "${BIN}"
+  if [ "${EXCLUDE}" = "0" ]; then
+   print_bold_nl "${ARROWS} Restoring Crosstools"
+   mv ${PORTS}/linux* ${BIN}/bin/
   fi
-  print_bold_nl ">>> Done.  You may now redownload or even choose another branch."
+  print_bold_nl "${ARROWS} Done.  You may now redownload or even choose another branch."
  ;;
  deposit-rom)
   deposit-rom
@@ -359,7 +388,7 @@ case $CMD in
   exit 1
  ;;
 esac
-if [ $GITCLEAN = 1 ]; 	then print_bold_nl ">>> Cleaning git artifacts.";		gitclean; 	fi
+if [ $GITCLEAN = 1 ]; 	then print_bold_nl "${ARROWS} Cleaning git artifacts.";		gitclean; 	fi
 freevars
 print_bold_nl "Please Amiga responsibly!"
 ## END MAIN ##

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -305,8 +305,8 @@ case $CMD in
  ;;
  list-rom-contents)
   check-deps
-	if [ ! -e "${WORK}/AROS.ROM" ]; then compile kernel; fi
-	printf "\033[1m ---- Start ROM Contents: ----\033[0m\n"
+  if [ ! -e "${WORK}/AROS.ROM" ]; then compile kernel; fi
+  printf "\033[1m ---- Start ROM Contents: ----\033[0m\n"
   strings "${WORK}/AROS.ROM" | grep "\$VER" | sed "s/i\$VER: //g" | sed "s/\$VER: //g" | sed "s/i\$VER://g" | sed "s/\$VER://g"
   printf "\033[1m ----- End ROM Contents: -----\033[0m\n"
  ;;

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -256,7 +256,7 @@ if [ $(pkgcheck; echo $?) = 1 ]; then
 fi
 if [ $DL = 1 ]; 	         then echo ">>> Source wipe requested, deleting."; 	rm -rf $SRC; 	fi
 if [ ! -e $SRC ]; 	         then echo ">>> Source not detected, downloading.";	download;	fi
-if [ $CLEAN = 1 ]; 	         then echo ">>> Fresh build requested, cleaning.";	makeeclean; 	fi
+if [ $CLEAN = 1 ]; 	         then echo ">>> Fresh build requested, cleaning.";	makeclean; 	fi
 
 case $CMD in
  dist)

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+shopt -s extglob
+
+## BEGIN Configuration ## Place your favorite configuration here.
+JOBS="$(cat /proc/cpuinfo | grep "processor" | wc -l)"
+CLEAN=0
+GITCLEAN=0
+DL=0
+WORK="apollo-os"
+REPO="https://github.com/ApolloTeam-dev/AROS"
+BRANCH="v4-alynna"
+REZ=640x256x4
+CPU=68040
+FPU=68881
+OPT=s
+VAMP=1
+CONF=0
+DEBUG=0
+CONFO=""
+MAKEO=""
+## END Configuration ##
+
+## BEGIN Variables ##
+setvars () {
+ DIR="$(pwd)"
+ SRC="$DIR/$WORK/src"
+ PORTS="$DIR/$WORK/prt"
+ BIN="$DIR/$WORK/bin"
+ CONFOPTS="--target=amiga-m68k --with-optimization=-O$OPT --with-aros-prefs=classic --with-resolution=$REZ --with-cpu=$CPU --with-fpu=$FPU --disable-mmu --with-portssources=$PORTS"
+ if [ $VAMP = 0 ]; then CONFOPTS="$CONFOPTS --with-nonvampire-support"; fi
+ if [ $DEBUG = 1 ]; then CONFOPTS="$CONFOPTS --enable-debug --with-serial-debug"; fi
+ MAKEOPTS="-j$JOBS"
+ PKGS="git gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python-mako libxcursor-dev gcc-multilib"
+ export CONFOPTS MAKEOPTS SRC PORTS BIN DIR PKGS
+}
+freevars () { unset CONFOPTS MAKEOPTS SRC PORTS BIN DIR BRANCH CLEAN DL CONF CONFO GITCLEAN JOBS MAKEO REZ VAMP WORK DEBUG CPU FPU OPT; }
+## END Variables ##
+
+## BEGIN FUNCTIONS ##
+defaults () {
+              echo -n "--branch=$BRANCH -c$CLEAN -d$DL -f$CONF -g$GITCLEAN --jobs=$JOBS -v$VAMP "
+              if [ $REZ = "640x200x4" ]; then echo -n "-n"; else echo -n "-p"; fi
+              echo " --work=$WORK --conf=\"$CONFO\" --make=\"$MAKEO\" --cpu=$CPU --fpu=$FPU --opt=$OPT"
+}
+deposit-rom () { if [ -e bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin ]; then
+                  cat $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin >$WORK/AROS.ROM
+                  echo ">>> RESULT: $(du $WORK/AROS.ROM)"
+                 fi
+}
+makeclean () { cd $BIN; make clean; cd $DIR; }
+gitclean () { cd $SRC; git clean -df; cd $DIR; }
+pkgcheck () { if [ $(dpkg-query -W -f '${Binary:Package} ${Status}\n' $PKGS | wc -l) -eq $(echo $PKGS | wc -w) ]; then return 0; else return 1; fi; }
+download () { cd $WORK; if [ ! -d $SRC ]; then git clone --recursive $REPO --branch=$BRANCH $SRC; cd $DIR; fi }
+configure () { cd $BIN; $SRC/configure $CONFOPTS $CONFO; cd $DIR; }
+compile () { cd $BIN; make $1 $MAKEOPTS $MAKEO; cd $DIR; }
+
+valid-cpu () { 
+ if [ "$1" = "" ]; then
+  echo "68000 68010 68020 68030 68040 68060"
+  return 0
+ else 
+  if [ "$1" == "680[12346]0" ]; then return 1; else return 0; fi
+ fi
+}
+
+valid-fpu () {
+ if [ "$1" = "" ]; then
+  echo "68881 soft-float hard-float"
+ else
+  if [ "$1" == "68881|soft-float|hard-float" ]; then return 1; else return 0; fi
+ fi
+}
+
+
+loop-through-opts () {
+for i in "$@"; do
+ case $i in
+  -b=*|--branch=*)
+   BRANCH="${i#*=}"
+   shift
+  ;;
+  -b0|--no-branch)
+   BRANCH=""
+   shift
+  ;;
+  -c|-c1|--clean)
+   CLEAN=1
+   shift
+  ;;
+  -c0|--no-clean)
+   CLEAN=0
+   shift
+  ;;
+  -d|-d1|--download)
+   DL=1
+   shift
+  ;;
+  -d0|--no-download)
+   DL=0
+   shift
+  ;;
+  -f|-f1|--conf)
+   CONF=1
+   shift
+  ;;
+  -f0|--no-conf)
+   CONF=0
+   shift
+  ;;
+  -f=*|--conf=*)
+   CONFO="${i#*=}"
+   shift
+  ;;
+  -g|-g1|--gitclean)
+   GITCLEAN=1
+   shift
+  ;;
+  -g0|--no-gitclean)
+   GITCLEAN=0
+   shift
+  ;;
+  -j=*|--jobs=*)
+   JOBS="${i#*=}"
+   shift
+  ;;
+  -j)
+   JOBS=$(cat /proc/cpuinfo | grep "processor" | wc -l)
+   shift
+  ;;
+  -m=*|--make=*)
+   MAKEO="${i#*=}"
+   shift
+  ;;
+  -m0|--no-make)
+   MAKEO=""
+   shift
+  ;;
+  -n|--ntsc)
+   REZ="640x200x4"
+   shift
+  ;;
+  -p|--pal)
+   REZ="640x256x4"
+   shift
+  ;;
+  -v|-v1|--vamp)
+   VAMP=1
+   shift
+  ;;
+  -v0|--no-vamp)
+   VAMP=0
+   shift
+  ;;
+  -w=*|--work=*)
+   WORK="${i#*=}"
+   shift
+  ;;
+  --cpu=*)
+   CPU="${i#*=}"
+   shift
+  ;;
+  --fpu=*)
+   FPU="${i#*=}"
+   shift
+  ;;
+  -o=*|--opt=*)
+   OPT="${i#*=}"
+   shift
+  ;;
+  --debug|--debug=1)
+   DEBUG=1
+   shift
+  ;;
+  --no-debug|--debug=0)
+   DEBUG=0
+   shift
+  ;;
+  *)
+   if [ "$CMD" = "" ]; then CMD=$i; shift;
+   else (echo "!!! There seems to be an issue with your Options." >&2); shift; exit 2
+   fi
+ esac
+ export BRANCH CLEAN DL CONF CONFO GITCLEAN JOBS MAKEO REZ VAMP WORK CMD CPU FPU OPT DEBUG
+done
+}
+
+help () {
+cat << EOF
+mkapollo.sh -- Roll your own ApolloOS image and ROM
+
+ Syntax: mkapollo.sh [options] <command> [args]
+
+ Commands:
+  all                         Run configure, make distfiles and ROM (Start here!)
+  dist                        Just make distfiles
+  kernel                      Just make ROM
+  wipe                        Starts from near fresh (leaves ports)
+  null                        Just parse options
+
+ Options:
+  -b,--branch=<branch>        Select different branch
+  -c,--clean                  Make clean first
+  -d,--download               Delete source and redownload
+  -f,--conf                   Run configure first
+  --conf=<opts>               Add configure options
+  -g,--gitclean               Clean for git committing (after other operations)
+  --jobs=#                    Specify number of compile threads
+  -j                          One compile thread for each cpu
+  --make=<opts>               Add make options
+  -n,--ntsc                   Select NTSC build
+  -o,--opt=#                  Select optimization level
+  -p,--pal                    Select PAL build
+  -v,--vamp                   Compile for True Vampires
+  -w,--work=<dir>             Work directory (will be created if not present)
+  --cpu=<cpu>                 Specify target CPU
+  --fpu=<fpu>                 Specify target FPU
+  --debug                     Enable debugging
+
+  Defaults can be changed at the top of this file.
+  Nearly all options take a boolean 0/1 to override defaults, as well as --no-<option>
+  
+  Valid optimization levels: s 0 1 2 3
+EOF
+echo "  Valid CPUs               : $(valid-cpu)"
+echo "  Valid FPUs               : $(valid-fpu)"
+cat << EOF
+
+ Note that source will be downloaded if it is not found at the location.
+ If you just want your ROM, just do:  mkapollo.sh all
+ Then go get a coffee. Or a meal.
+
+ The current defaults are:
+EOF
+echo "  $(defaults)"
+echo -e "\nPlease Amiga responsibly."
+}
+## END FUNCTIONS ##
+
+## BEGIN MAIN ##
+loop-through-opts $@
+if [ "$CMD" = "" ]; 	then help; exit 1; 	fi
+
+setvars
+echo "Making ApolloOS:     $(defaults)"
+echo "Configuration:       $CONFOPTS"
+echo "Make options:        $MAKEOPTS"
+echo "Work directory:      $WORK"
+echo -n "3..."; sleep 1; echo -n "2..."; sleep 1; echo -n "1..."; sleep 1; echo "Go!";
+
+mkdir -p $BIN
+
+if [ $(pkgcheck; echo $?) = 1 ]; then
+ echo ">>> You are missing required packages to build ApolloOS.  Attempting to install."
+ apt -y update
+ apt -y install $PKGS
+fi
+if [ $DL = 1 ]; 	         then echo ">>> Source wipe requested, deleting."; 	rm -rf $SRC; 	fi
+if [ ! -e $SRC ]; 	         then echo ">>> Source not detected, downloading.";	download;	fi
+if [ $CLEAN = 1 ]; 	         then echo ">>> Fresh build requested, cleaning.";	makeeclean; 	fi
+
+case $CMD in
+ dist)
+  if [ $CONF = 1 ] || [ ! -e $BIN/config.status ]; then configure; fi
+  compile distfiles
+ ;;
+ kernel)
+  if [ $CONF = 1 ] || [ ! -e $BIN/config.status ]; then configure; fi
+  compile kernel
+  deposit-rom
+ ;;
+ all)
+  configure
+  compile
+  compile distfiles
+  compile kernel
+  deposit-rom
+ ;;
+ wipe)
+  rm -rf $SRC
+  rm -rf $BIN
+ ;;
+ *)
+  help
+  exit 1
+ ;;
+esac
+if [ $GITCLEAN = 1 ]; 	then echo ">>> Cleaning git artifacts.";		gitclean; 	fi
+freevars
+echo "Please Amiga responsibly."
+## END MAIN ##

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -204,6 +204,8 @@ done
 help () {
 cat << EOF
 mkapollo.sh -- Roll your own ApolloOS image and ROM
+ (C) 2021 Alynna Trypnotk, License APL 1.1:
+ https://github.com/ApolloTeam-dev/AROS/blob/master-new/LICENSE
 
  It does what NintenDon't.
  Syntax: mkapollo.sh [options] <command> [args]

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -15,7 +15,7 @@ AMIGADATE="$(date +"%-d.%-m.%Y")"
 if [ -e ".git" ]; then
 	BRANCH="$(git branch --show-current)"
 	REMOTE=$(git status -sb | sed "s/\#\#\ ${BRANCH}\.\.\.//g" | sed "s/\/${BRANCH}//g" | head -n 1)
-	REPO="$(git remote get-url ${REMOTE})"
+	REPO="$(git remote get-url "${REMOTE}")"
 else
 	REPO="https://github.com/ApolloTeam-dev/AROS"
 	BRANCH="v4-alynna"
@@ -58,8 +58,9 @@ setvars () {
 	if [ ${VAMP} = 0 ];		then CONFOPTS="${CONFOPTS} --with-nonvampire-support"; fi
 	if [ ${DEBUG} = 1 ];	then CONFOPTS="${CONFOPTS} --enable-debug --with-serial-debug"; fi
 	MAKEOPTS="-j${JOBS}"
-	PKGS="git gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python3-mako libxcursor-dev gcc-multilib"
+	PKGS="git gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python-mako libxcursor-dev gcc-multilib"
 
+	mkdir -p "${DIR}/${WORK}"
 	VERSION_FILE="${DIR}/${WORK}/dist_config.h"
 
 	printf "#ifndef AROS_DIST_CONFIG_H\n#define AROS_DIST_CONFIG_H\n\n" > "${VERSION_FILE}"
@@ -92,7 +93,7 @@ deposit-rom () {
 		 if [ -e "${BIN}/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin" ]; then
                   cat "${BIN}/bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin" "${BIN}/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin" > "${WORK}/AROS.ROM"
                   print_bold "${ARROWS} ${BOLD}${GREEN}ROM RESULT:${NC} "
-                  read -r ROMSIZE ROMSIZETYPE ROMFILEPATH <<< "$(du --apparent-size -h apollo-os/AROS.ROM |sed -re "s|([0-9\.]+)([a-Z])\t([-/a-Z\.]+)|\1 \2 \3|g")"
+                  read -r ROMSIZE ROMSIZETYPE ROMFILEPATH <<< "$(du --apparent-size -h ${WORK}/AROS.ROM |sed -re "s|([0-9\.]+)([a-Z])\t([-/a-Z\.]+)|\1 \2 \3|g")"
 
                   # shellcheck disable=SC2072
                   MAXROMSIZE=1.0
@@ -386,8 +387,8 @@ mkdir -p "${BIN}"
 
 if [ $(pkgcheck; echo $?) = 1 ]; then
  print_bold_nl "${ARROWS} ${BOLD}${RED}You are missing required packages to build ApolloOS!  ${GREEN}Attempting to install...${NC}"
- sudo apt -y update
- sudo apt -y install ${PKGS}
+ apt -y update
+ apt -y install "${PKGS}"
 fi
 if [ $DL = 1 ];                 then print_bold_nl "${ARROWS} Source wipe requested, ${RED}deleting${NC}.";     rm -rf "${SRC}"; fi
 if [ ! -e "${SRC}/configure" ]; then print_bold_nl "${ARROWS} Source not detected, ${GREEN}downloading${NC}.";  download;	       fi
@@ -425,6 +426,7 @@ case $CMD in
   fi
   print_bold_nl "${ARROWS} Removing Binaries (Things in the work dir root are preserved)"
   rm -rf "${BIN}"
+
   if [ "${EXCLUDE}" = "0" ]; then
    print_bold_nl "${ARROWS} Restoring Crosstools"
    mkdir -p ${BIN}/bin/
@@ -434,6 +436,9 @@ case $CMD in
  ;;
  deposit-rom)
   deposit-rom
+ ;;
+ i2c)
+  compile workbench-c-i2c-quick
  ;;
  *)
   help

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -2,13 +2,14 @@
 shopt -s extglob
 
 ## BEGIN Configuration ## Place your favorite configuration here.
-JOBS="$(cat /proc/cpuinfo | grep "processor" | wc -l)"
+JOBS="$(nproc)"
 CLEAN=0
 GITCLEAN=0
 DL=0
 WORK="apollo-os"
-REPO="https://github.com/ApolloTeam-dev/AROS"
-BRANCH="v4-alynna"
+BRANCH="$(git branch --show-current)"
+REMOTE=$(git status -sb | sed "s/\#\#\ ${BRANCH}\.\.\.//g" | sed "s/\/${BRANCH}//g" | head -n 1)
+REPO="$(git remote get-url ${REMOTE})"
 REZ=640x256x4
 CPU=68040
 FPU=68881
@@ -43,7 +44,7 @@ defaults () {
               if [ $REZ = "640x200x4" ]; then echo -n "-n"; else echo -n "-p"; fi
               echo " --work=$WORK --conf=\"$CONFO\" --make=\"$MAKEO\" --cpu=$CPU --fpu=$FPU --opt=$OPT"
 }
-deposit-rom () { 
+deposit-rom () {
 		 if [ -e $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf ]; then
                   cp $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf $WORK/
                   echo ">>> ADF RESULT: $(du --apparent-size -h $WORK/bootdisk-amiga-m68k.adf)"
@@ -68,11 +69,11 @@ download () { cd $WORK; if [ ! -d $SRC ]; then git clone --recursive $REPO --bra
 configure () { cd $BIN; $SRC/configure $CONFOPTS $CONFO; cd $DIR; }
 compile () { cd $BIN; make $1 $MAKEOPTS $MAKEO; cd $DIR; }
 
-valid-cpu () { 
+valid-cpu () {
  if [ "$1" = "" ]; then
   echo "68000 68010 68020 68030 68040 68060"
   return 0
- else 
+ else
   if [ "$1" == "680[12346]0" ]; then return 1; else return 0; fi
  fi
 }

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -58,7 +58,7 @@ setvars () {
 	if [ ${VAMP} = 0 ];		then CONFOPTS="${CONFOPTS} --with-nonvampire-support"; fi
 	if [ ${DEBUG} = 1 ];	then CONFOPTS="${CONFOPTS} --enable-debug --with-serial-debug"; fi
 	MAKEOPTS="-j${JOBS}"
-	PKGS="git gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python-mako libxcursor-dev gcc-multilib"
+	PKGS="git gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python3-mako libxcursor-dev gcc-multilib"
 
 	VERSION_FILE="${DIR}/${WORK}/dist_config.h"
 
@@ -386,8 +386,8 @@ mkdir -p "${BIN}"
 
 if [ $(pkgcheck; echo $?) = 1 ]; then
  print_bold_nl "${ARROWS} ${BOLD}${RED}You are missing required packages to build ApolloOS!  ${GREEN}Attempting to install...${NC}"
- apt -y update
- apt -y install "${PKGS}"
+ sudo apt -y update
+ sudo apt -y install ${PKGS}
 fi
 if [ $DL = 1 ];                 then print_bold_nl "${ARROWS} Source wipe requested, ${RED}deleting${NC}.";     rm -rf "${SRC}"; fi
 if [ ! -e "${SRC}/configure" ]; then print_bold_nl "${ARROWS} Source not detected, ${GREEN}downloading${NC}.";  download;	       fi

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -68,22 +68,33 @@ defaults () {
 deposit-rom () {
 		 if [ -e $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf ]; then
                   cp $BIN/bin/amiga-m68k/gen/boot/bootdisk-amiga-m68k.adf $WORK/
-                  print_bold_nl "${ARROWS} ADF RESULT: $(du --apparent-size -h $WORK/bootdisk-amiga-m68k.adf)"
+                  print_bold_nl "${ARROWS} ${BOLD}${GREEN}ADF RESULT:${NC} $(du --apparent-size -h $WORK/bootdisk-amiga-m68k.adf)"
                  fi
 
 		 if [ -e $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin ]; then
                   cat $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin $BIN/bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin >$WORK/AROS.ROM
-                  echo "${ARROWS} ROM RESULT: $(du --apparent-size -h $WORK/AROS.ROM)"
+                  print_bold "${ARROWS} ${BOLD}${GREEN}ROM RESULT:${NC} "
+                  read -r ROMSIZE ROMSIZETYPE ROMFILEPATH <<<$(du --apparent-size -h apollo-os/AROS.ROM |sed -re "s|([0-9\.]+)([a-Z])\t([-/a-Z\.]+)|\1 \2 \3|g")
+
+                  # shellcheck disable=SC2072
+                  MAXROMSIZE=1.0
+                  printf "%s%s\t%s" "${ROMSIZE}" "${ROMSIZETYPE}" "${ROMFILEPATH}"
+
+                  if [[ ((${ROMSIZE} > ${MAXROMSIZE})) ]] && [ "${ROMSIZETYPE}" == "M" ]; then
+                   print_bold_nl " -- ${RED}BAD ROM SIZE${NC}"
+                  else
+                   print_bold_nl " -- ${GREEN}ROM SIZE OK${NC}"
+                  fi
                  fi
 
 		 if [ -e $BIN/distfiles/aros-amiga-m68k.iso ]; then
                   cp $BIN/distfiles/aros-amiga-m68k.iso $WORK/
-                  echo "${ARROWS} ISO RESULT: $(du --apparent-size -h $WORK/aros-amiga-m68k.iso)"
+                  echo "${ARROWS} ${BOLD}${GREEN}ISO RESULT:${NC} $(du --apparent-size -h $WORK/aros-amiga-m68k.iso)"
                  fi
 
 		 if [ -e $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device ]; then
                   cp $BIN/bin/amiga-m68k/AROS.HUNK/Devs/sagasd.device $WORK/
-                  echo "${ARROWS} SD0 RESULT: $(du --apparent-size -h $WORK/sagasd.device)"
+                  echo "${ARROWS} ${BOLD}${GREEN}SD0 RESULT:${NC} $(du --apparent-size -h $WORK/sagasd.device)"
                  fi
 }
 

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -330,10 +330,11 @@ print_bold_nl "Please Amiga responsibly."
 }
 
 check-deps () {
-	if [ ${CONF} = 1 ] || [ ! -e "${BIN}/config.status" ];								then configure;												fi
-	if [ ! -e "${BIN}/bin/linux-x86_64/tools/crosstools/m68k-aros-gcc" ];	then compile tools-crosstools-gcc;	fi
-	if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ];										then compile mmake;								fi
-	if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ];											then compile sfdc;									fi
+	if [ ${CONF} = 1 ] || [ ! -e "${BIN}/config.status" ];								then configure;													fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/crosstools/m68k-aros-gcc" ];	then compile tools-crosstools-gcc;			fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/mmake" ];										then compile mmake;											fi
+	if [ ! -e "${BIN}/bin/linux-x86_64/tools/sfdc" ];											then compile sfdc;											fi
+	if [ ! -e "${BIN}/bin/amiga-m68k/gen/include/zconf.h" ];							then compile workbench-libs-z-includes;	fi
 }
 
 list-rom-contents () {
@@ -416,7 +417,7 @@ case $CMD in
   print_bold_nl "!!! CTRL-AMIGA-AMIGA Pressed !!!"
   if [ ! -e ".git" ]; then
    print_bold_nl "${ARROWS} Removing sources"
-   rm -rf $SRC
+   rm -rf "${SRC}"
   fi
   if [ "$EXCLUDE" = "0" ]; then
    print_bold_nl "${ARROWS} Preserving Crosstools (saves serious recompile time)"

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -337,7 +337,7 @@ print_bold "${YELLOW}Work directory:  "
 printf "%s\n" "${WORK}"
 
 print_bold "${YELLOW}Starting in:     "
-#echo -n "3..."; sleep 1; echo -n "2..."; sleep 1; echo -n "1..."; sleep 1; print_bold_nl "${GREEN}Go!";
+echo -n "3..."; sleep 1; echo -n "2..."; sleep 1; echo -n "1..."; sleep 1; print_bold_nl "${GREEN}Go!";
 
 mkdir -p "${BIN}"
 
@@ -365,7 +365,6 @@ case $CMD in
   if [ ! -e "${WORK}/AROS.ROM" ]; then compile kernel; fi
   print_bold_nl ""
   print_bold_nl "${YELLOW} ---- ${GREEN}Start ROM Contents: ${YELLOW}----${NC}"
-  #strings "${WORK}/AROS.ROM" | grep "\$VER" | sed "s/i\$VER: //g" | sed "s/\$VER: //g" | sed "s/i\$VER://g" | sed "s/\$VER://g"
   readarray a <<< $(strings "${WORK}/AROS.ROM" | grep "\$VER" | sed -re 's|.*\$VER\:\s*([\.\-\_a-Z0-9]+)\s*([-a-Z0-9\_]*)\s([\.0-9]+)\s([0-9\(\)\.]+)(.*)|\1 \"\2\" \3 \4|g')
 
   for element in "${a[@]}"; do

--- a/mkapollo.sh
+++ b/mkapollo.sh
@@ -7,6 +7,9 @@ CLEAN=0
 GITCLEAN=0
 DL=0
 WORK="apollo-os"
+DISTRONAME="ApolloOS"
+DISTROVERSION="$(cat version)"
+DISTRODATE="$(date +%Y-%m-%d)"
 if [ -e ".git" ]; then
 	BRANCH="$(git branch --show-current)"
 	REMOTE=$(git status -sb | sed "s/\#\#\ ${BRANCH}\.\.\.//g" | sed "s/\/${BRANCH}//g" | head -n 1)
@@ -15,6 +18,8 @@ else
 	REPO="https://github.com/ApolloTeam-dev/AROS"
 	BRANCH="v4-alynna"
 fi
+
+TEST_CFLAGS="-D__DISTRONAME__='\"${DISTRONAME}\"' -D__DISTROVERSION__='\"${DISTROVERSION}\"' -D__DISTRODATE__='\"${DISTRODATE}\"'"
 REZ=640x256x4
 CPU=68040
 FPU=68881
@@ -103,7 +108,7 @@ gitclean  () { cd "${SRC}" || exit; git clean -df; cd "${DIR}" || exit; }
 pkgcheck  () { if [ $(dpkg-query -W -f '${Binary:Package} ${Status}\n' $PKGS | wc -l) -eq $(echo $PKGS | wc -w) ]; then return 0; else return 1; fi; }
 download  () { cd "${WORK}" || exit; if [ ! -d $SRC ]; then git clone --recursive $REPO --branch=$BRANCH $SRC; cd $DIR; fi }
 configure () { cd "${BIN}" || exit; ${SRC}/configure $CONFOPTS $CONFO; cd $DIR; }
-compile   () { cd "${BIN}" || exit; make $1 $MAKEOPTS $MAKEO; cd $DIR; }
+compile   () { cd "${BIN}" || exit; touch "${SRC}/rom/dosboot/menu.c"; make CFLAGS="${TEST_CFLAGS}" ${1} ${MAKEOPTS} ${MAKEO}; cd ${DIR}; }
 
 valid-cpu () {
 	if [ "$1" = "" ]; then

--- a/mkuae
+++ b/mkuae
@@ -1,0 +1,2 @@
+#!/bin/bash
+./mkapollo.sh -v0 $@

--- a/mkv4
+++ b/mkv4
@@ -1,0 +1,2 @@
+#!/bin/bash
+./mkapollo.sh -v1 --work=apollo-v4 $@


### PR DESCRIPTION
### The `mkapollo.sh` script does the following:
- Makes sure dependencies are properly installed before building
- Decreases failure rate during build
- Enables easy versioning in early boot console
- Easier to build multiple version from same repo folder for both testing in UAE and on V4
- Makes it easy to list contents of ROM
- Bundles all build output in one folder and show you the output path
- Automatically combines ROM + EXT-ROM into a ApolloOS 1MB ROM for easy mapping on V4
- Installs required packages for building on Debian/Ubuntu
- Provides a way to easily get started for new developers

**This PR doesn't remove the existing build scripts and is broken out of #27**