### PR TITLE
Increased priority of memory for the V4

### DIFF
--- a/arch/m68k-amiga/boot/start.c
+++ b/arch/m68k-amiga/boot/start.c
@@ -351,6 +351,10 @@ static struct MemHeader *addmemoryregion(ULONG startaddr, ULONG size, struct Boo
         krnCreateMemHeader("chip memory", -10,
             (APTR)startaddr, size,
             MEMF_CHIP | MEMF_KICK | MEMF_PUBLIC | MEMF_LOCAL | MEMF_24BITDMA);
+    } else if (startaddr = 0x01000000) {
+        krnCreateMemHeader("fast memory", 50,
+            (APTR)startaddr, size,
+            MEMF_FAST | MEMF_KICK | MEMF_PUBLIC | MEMF_LOCAL );
     } else {
         krnCreateMemHeader("memory", -5, 
             (APTR)startaddr, size,


### PR DESCRIPTION
This is a patch from Gunnar von Boehn to increase the priority of fast ram of the V4.  Should help avoid using slower ram on A2k machines until all of the V4's fast ram is used up.