### PR TITLE
8M IDE Cache Size

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.13.4 -*- Autoconf -*-
+# generated automatically by aclocal 1.16.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
+# Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -198,7 +198,7 @@ int main(int argc, char *argv[])
   rm -f conf.sdltest
 ])
 
-# Copyright (C) 1999-2013 Free Software Foundation, Inc.
+# Copyright (C) 1999-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -232,8 +232,11 @@ AC_DEFUN([AM_PATH_PYTHON],
   dnl Find a Python interpreter.  Python versions prior to 2.0 are not
   dnl supported. (2.0 was released on October 16, 2000).
   m4_define_default([_AM_PYTHON_INTERPRETER_LIST],
-[python python2 python3 python3.3 python3.2 python3.1 python3.0 python2.7 dnl
- python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python2.0])
+[python python2 python3 dnl
+ python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 dnl
+ python3.2 python3.1 python3.0 dnl
+ python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 dnl
+ python2.0])
 
   AC_ARG_VAR([PYTHON], [the Python interpreter])
 
@@ -433,7 +436,7 @@ for i in list(range(0, 4)): minverhex = (minverhex << 8) + minver[[i]]
 sys.exit(sys.hexversion < minverhex)"
   AS_IF([AM_RUN_LOG([$1 -c "$prog"])], [$3], [$4])])
 
-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
+# Copyright (C) 2001-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/config/host-conf.h.in
+++ b/config/host-conf.h.in
@@ -17,6 +17,9 @@
 /* Define to 1 if you have the `getpagesize' function. */
 #undef HAVE_GETPAGESIZE
 
+/* Define to 1 if you have the <GL/glx.h> header file. */
+#undef HAVE_GL_GLX_H
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
@@ -25,9 +28,6 @@
 
 /* Define to 1 if you have the `kse_create' function. */
 #undef HAVE_KSE_CREATE
-
-/* Define to 1 if you have the `png' library (-lpng). */
-#undef HAVE_LIBPNG
 
 /* Define to 1 if you have the `makecontext' function. */
 #undef HAVE_MAKECONTEXT

--- a/configure
+++ b/configure
@@ -977,6 +977,7 @@ with_theme
 enable_includes
 with_resolution
 with_nonvampire_support
+with_vampirecard_series
 with_serial_debug
 enable_palm_debug_hack
 enable_usb30_code
@@ -1749,6 +1750,9 @@ Optional Packages:
                           Default resolution of the initial WorkbenchScreen
   --with-nonvampire-support
                           Enable support for non-vampires (default=no)
+  --with-vampirecard-series=VERSION
+                          Set for which series of vampire card the rom is to
+                          be built (default=v4)
   --with-serial-debug     Enable serial debug output in native (default=no)
   --with-x                use the X Window System
   --with-sdl-prefix=PFX   Prefix where SDL is installed (optional)
@@ -6416,7 +6420,7 @@ if ${am_cv_pathless_PYTHON+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
-	for am_cv_pathless_PYTHON in python python2 python3 python3.3 python3.2 python3.1 python3.0 python2.7  python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python2.0 none; do
+	for am_cv_pathless_PYTHON in python python2 python3  python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3  python3.2 python3.1 python3.0  python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1  python2.0 none; do
 	  test "$am_cv_pathless_PYTHON" = none && break
 	  prog="import sys
 # split strings by '.' and convert to numeric.  Append some zeros
@@ -15308,6 +15312,32 @@ $as_echo "Enabling nonvampire support" >&6; }
 else
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking Vampire card series: v2 or v4  " >&5
+$as_echo_n "checking Vampire card series: v2 or v4  ... " >&6; }
+
+# Check whether --with-vampirecard-series was given.
+if test "${with_vampirecard_series+set}" = set; then :
+  withval=$with_vampirecard_series; vampirecard_series="$withval"
+else
+  vampirecard_Series="v4"
+fi
+
+if test "$vampirecard_series" = "v2" ; then
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: Vampire Card Series v2 " >&5
+$as_echo "Vampire Card Series v2 " >&6; }
+	aros_config_cppflags="$aros_config_cppflags -DVAMPIRECARDSERIES=2"
+	aros_config_cflags="$aros_config_cflags -DVAMPIRECARDSERIES=2"
+	aros_kernel_cppflags="$aros_kernel_cppflags -DVAMPIRECARDSERIES=2"
+	aros_kernel_cflags="$aros_kernel_cflags -DVAMPIRECARDSERIES=2"
+else
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: Vampire Card Series v4 " >&5
+$as_echo "Vampire Card Series v4 " >&6; }
+	aros_config_cppflags="$aros_config_cppflags -DVAMPIRECARDSERIES=4"
+	aros_config_cflags="$aros_config_cflags -DVAMPIRECARDSERIES=4"
+	aros_kernel_cppflags="$aros_kernel_cppflags -DVAMPIRECARDSERIES=4"
+	aros_kernel_cflags="$aros_kernel_cflags -DVAMPIRECARDSERIES=4"
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether serial debug is enabled" >&5

--- a/configure.in
+++ b/configure.in
@@ -3014,20 +3014,20 @@ else
 fi
 
 dnl check to see if we are enabling support for the V2
-AC_MSG_CHECKING([Vampire card series (v2 or v2)] )
-AC_ARG_WITH(vampirecard-series,AC_HELP_STRING([--vampirecard-series],[Set for which series of vampire card the rom is to be built (default=v4)]),vampirecard_series=$withval,vampirecard_Series=v4)
-if test "$vampirecard_Series" = "v2"; then
-	AC_MSG_RESULT(Vampire Card Series v2)
-	aros_config_cppflags="$aros_config_cppflags -DVAMPIRECARD_SERIES=v2"
-	aros_config_cflags="$aros_config_cflags -DVAMPIRECARD_SERIES=v2"
-	aros_kernel_cppflags="$aros_kernel_cppflags -DVAMPIRECARD_SERIES=v2"
-	aros_kernel_cflags="$aros_kernel_cflags -DVAMPIRECARD_SERIES=v2"
+AC_MSG_CHECKING([Vampire card series: v2 or v4 ] )
+AC_ARG_WITH(vampirecard-series,AC_HELP_STRING([--with-vampirecard-series=VERSION],[Set for which series of vampire card the rom is to be built (default=v4)]),vampirecard_series="$withval",vampirecard_Series="v4")
+if test "$vampirecard_series" = "v2" ; then
+	AC_MSG_RESULT(Vampire Card Series v2 )
+	aros_config_cppflags="$aros_config_cppflags -DVAMPIRECARDSERIES=2"
+	aros_config_cflags="$aros_config_cflags -DVAMPIRECARDSERIES=2"
+	aros_kernel_cppflags="$aros_kernel_cppflags -DVAMPIRECARDSERIES=2"
+	aros_kernel_cflags="$aros_kernel_cflags -DVAMPIRECARDSERIES=2"
 else
-	AC_MSG_RESULT(Vampire Card Series v4)
-	aros_config_cppflags="$aros_config_cppflags -DVAMPIRECARD_SERIES=v4"
-	aros_config_cflags="$aros_config_cflags -DVAMPIRECARD_SERIES=v4"
-	aros_kernel_cppflags="$aros_kernel_cppflags -DVAMPIRECARD_SERIES=v4"
-	aros_kernel_cflags="$aros_kernel_cflags -DVAMPIRECARD_SERIES=v4"
+	AC_MSG_RESULT(Vampire Card Series v4 )
+	aros_config_cppflags="$aros_config_cppflags -DVAMPIRECARDSERIES=4"
+	aros_config_cflags="$aros_config_cflags -DVAMPIRECARDSERIES=4"
+	aros_kernel_cppflags="$aros_kernel_cppflags -DVAMPIRECARDSERIES=4"
+	aros_kernel_cflags="$aros_kernel_cflags -DVAMPIRECARDSERIES=4"
 fi
 
 dnl See if the user wants the serial debug output for native flavour

--- a/configure.in
+++ b/configure.in
@@ -3013,6 +3013,23 @@ else
 	AC_MSG_RESULT(no)
 fi
 
+dnl check to see if we are enabling support for the V2
+AC_MSG_CHECKING([Vampire card series (v2 or v2)] )
+AC_ARG_WITH(vampirecard-series,AC_HELP_STRING([--vampirecard-series],[Set for which series of vampire card the rom is to be built (default=v4)]),vampirecard_series=$withval,vampirecard_Series=v4)
+if test "$vampirecard_Series" = "v2"; then
+	AC_MSG_RESULT(Vampire Card Series v2)
+	aros_config_cppflags="$aros_config_cppflags -DVAMPIRECARD_SERIES=v2"
+	aros_config_cflags="$aros_config_cflags -DVAMPIRECARD_SERIES=v2"
+	aros_kernel_cppflags="$aros_kernel_cppflags -DVAMPIRECARD_SERIES=v2"
+	aros_kernel_cflags="$aros_kernel_cflags -DVAMPIRECARD_SERIES=v2"
+else
+	AC_MSG_RESULT(Vampire Card Series v4)
+	aros_config_cppflags="$aros_config_cppflags -DVAMPIRECARD_SERIES=v4"
+	aros_config_cflags="$aros_config_cflags -DVAMPIRECARD_SERIES=v4"
+	aros_kernel_cppflags="$aros_kernel_cppflags -DVAMPIRECARD_SERIES=v4"
+	aros_kernel_cflags="$aros_kernel_cflags -DVAMPIRECARD_SERIES=v4"
+fi
+
 dnl See if the user wants the serial debug output for native flavour
 AC_MSG_CHECKING([whether serial debug is enabled])
 AC_ARG_WITH(serial-debug,AC_HELP_STRING([--with-serial-debug],[Enable serial debug output in native (default=no)]),serial_debug=$withval,serial_debug=none)

--- a/rom/devs/ata/ata.h
+++ b/rom/devs/ata/ata.h
@@ -2,7 +2,7 @@
 #define _ATA_H
 
 /*
-    Copyright © 2004-2019, The AROS Development Team. All rights reserved.
+    Copyright ï¿½ 2004-2019, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: ata.device main private include file
@@ -38,7 +38,12 @@
 #define STACK_SIZE              16384
 #define TASK_PRI                10
 #define TIMEOUT                 30
-#define CACHE_SIZE_BITS         17      /* 2^11 * 512 byte blocks (min 9)*/
+#if VAMPIRECARD_SERIES=v2
+#error TESTING
+#define CACHE_SIZE_BITS         14      /* 2^14 * 512 byte blocks */
+#else
+#define CACHE_SIZE_BITS         17      /* 2^17 * 512 byte blocks (min 9)*/
+#endif
 #define CACHE_SIZE              (1<<CACHE_SIZE_BITS)
 #define CACHE_MASK              (CACHE_SIZE-1)
 

--- a/rom/devs/ata/ata.h
+++ b/rom/devs/ata/ata.h
@@ -38,11 +38,10 @@
 #define STACK_SIZE              16384
 #define TASK_PRI                10
 #define TIMEOUT                 30
-#if VAMPIRECARD_SERIES=v2
-#error TESTING
+#if VAMPIRECARDSERIES==2
 #define CACHE_SIZE_BITS         14      /* 2^14 * 512 byte blocks */
 #else
-#define CACHE_SIZE_BITS         17      /* 2^17 * 512 byte blocks (min 9)*/
+#define CACHE_SIZE_BITS         14      //Maybe we increase this one day for V4 cards?
 #endif
 #define CACHE_SIZE              (1<<CACHE_SIZE_BITS)
 #define CACHE_MASK              (CACHE_SIZE-1)


### PR DESCRIPTION
Sets the cache size for the IDE driver to 8Mb.
The build system also has a new option added to allow for the specifying of Vampire Card series.  This is currently unused but might be in the future.