### PR TITLE
Fix to build pipeline (python-mako)

### DIFF
--- a/.github/workflows/BuildApolloOS.yml
+++ b/.github/workflows/BuildApolloOS.yml
@@ -36,7 +36,7 @@ jobs:
       
       # Install pre-reuisites
       - name: Install Prerequisites
-        run: sudo apt-get install git-core gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python-mako libxcursor-dev gcc-multilib zip genisoimage
+        run: sudo apt-get install git-core gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python3-mako libxcursor-dev gcc-multilib zip genisoimage
 
       # Runs a single command using the runners shell
       - name: configure

--- a/.github/workflows/BuildApolloOS.yml
+++ b/.github/workflows/BuildApolloOS.yml
@@ -36,7 +36,7 @@ jobs:
       
       # Install pre-reuisites
       - name: Install Prerequisites
-        run: sudo apt-get install git-core gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python3-mako libxcursor-dev gcc-multilib zip genisoimage
+        run: sudo apt-get install git-core gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc libxcursor-dev gcc-multilib zip genisoimage
 
       # Runs a single command using the runners shell
       - name: configure

--- a/.github/workflows/BuildApolloOS_UAE.yml
+++ b/.github/workflows/BuildApolloOS_UAE.yml
@@ -34,7 +34,7 @@ jobs:
       
       # Install pre-reuisites
       - name: Install Prerequisites
-        run: sudo apt-get install git-core gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc python-mako libxcursor-dev gcc-multilib zip genisoimage
+        run: sudo apt-get install git-core gcc g++ make cmake gawk bison flex bzip2 netpbm autoconf automake libx11-dev libxext-dev libc6-dev liblzo2-dev libxxf86vm-dev libpng-dev libsdl1.2-dev byacc libxcursor-dev gcc-multilib zip genisoimage
 
       # Runs a single command using the runners shell
       - name: configure


### PR DESCRIPTION
This prerequisite package has been removed from the build pipeline.  It seems it isn't needed.  And without it, the pipeline succeeds again.