### PR TITLE
Fixes to the Build Scripts and Build Pipeline as well as Alignment of GetVar()

### DIFF
--- a/.github/workflows/BuildApolloOS.yml
+++ b/.github/workflows/BuildApolloOS.yml
@@ -44,15 +44,15 @@ jobs:
 
       # build the compilers
       - name: Compiler Build
-        run: make -j6 compiler
+        run: make compiler
 
       # Runs a set of commands using the runners shell
       - name: make
-        run: make -j6
+        run: make 
         
       # make dist files
       - name: distfiles
-        run: make -j6 distfiles
+        run: make distfiles
         
       # Make the rom
       - name: aros.rom

--- a/.github/workflows/BuildApolloOS.yml
+++ b/.github/workflows/BuildApolloOS.yml
@@ -20,7 +20,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     #runs-on: [self-hosted, linux, X64]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/BuildApolloOS.yml
+++ b/.github/workflows/BuildApolloOS.yml
@@ -44,15 +44,15 @@ jobs:
 
       # build the compilers
       - name: Compiler Build
-        run: make compiler
+        run: make -j4 compiler
 
       # Runs a set of commands using the runners shell
       - name: make
-        run: make 
+        run: make -j4
         
       # make dist files
       - name: distfiles
-        run: make distfiles
+        run: make -j4 distfiles
         
       # Make the rom
       - name: aros.rom

--- a/.github/workflows/BuildApolloOS_UAE.yml
+++ b/.github/workflows/BuildApolloOS_UAE.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     #runs-on: [self-hosted, linux, X64]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/BuildApolloOS_UAE.yml
+++ b/.github/workflows/BuildApolloOS_UAE.yml
@@ -42,15 +42,15 @@ jobs:
 
       # build the compilers
       - name: Compiler Build
-        run: make -j6 compiler
+        run: make -j4 compiler
 
       # Runs a set of commands using the runners shell
       - name: make
-        run: make -j6
+        run: make -j4
         
       # make dist files
       - name: distfiles
-        run: make -j6 distfiles
+        run: make -j4 distfiles
         
       # Make the rom
       - name: aros.rom

--- a/rebuild_all.sh
+++ b/rebuild_all.sh
@@ -33,7 +33,7 @@ source ./make_dist_config.sh
 DISTOPTNAME="--enable-dist-name=${DISTRONAME}"
 DISTOPTVER="--enable-dist-version=${DISTROVERSION}"
 
-./configure "${DISTOPTNAME}" "${DISTOPTVER}" --target=amiga-m68k --with-optimization="-O2" --enable-ccache --with-aros-prefs=classic --with-resolution=640x256x4 --with-cpu=68040 --disable-mmu $@
+./configure "${DISTOPTNAME}" "${DISTOPTVER}" --target=amiga-m68k --with-optimization="-Os" --enable-ccache --with-aros-prefs=classic --with-resolution=640x256x4 --with-cpu=68040 --disable-mmu $@
 
 
 make -j${THREADS}

--- a/rebuild_rom.sh
+++ b/rebuild_rom.sh
@@ -3,9 +3,9 @@ CPU_COUNT=$(grep processor /proc/cpuinfo | wc -l)
 THREADS=${CPU_COUNT}
 
 #Some how, running more than 8 tasks doesn't succeed every time
-if [ ${THREADS} -gt  8 ]
+if [ ${THREADS} -gt  4 ]
 then
-	THREADS=8
+	THREADS=4
 fi
 
 args=("$@")

--- a/rebuild_rom.sh
+++ b/rebuild_rom.sh
@@ -34,7 +34,7 @@ source ./make_dist_config.sh
 DISTOPTNAME="--enable-dist-name=${DISTRONAME}"
 DISTOPTVER="--enable-dist-version=${DISTROVERSION}"
 
-./configure "${DISTOPTNAME}" "${DISTOPTVER}" --target=amiga-m68k --with-optimization="-O2" --enable-ccache --with-aros-prefs=classic --with-resolution=640x256x4 --with-cpu=68040 --disable-mmu $@
+./configure "${DISTOPTNAME}" "${DISTOPTVER}" --target=amiga-m68k --with-optimization="-Os" --enable-ccache --with-aros-prefs=classic --with-resolution=640x256x4 --with-cpu=68040 --disable-mmu $@
 
 make -j${THREADS}
 make -j${THREADS} kernel-amiga-m68k

--- a/rebuild_rom_with_debug.sh
+++ b/rebuild_rom_with_debug.sh
@@ -5,7 +5,7 @@ THREADS=${CPU_COUNT}
 #Some how, running more than 8 tasks doesn't succeed every time
 if [ ${THREADS} -gt  8 ]
 then
-	THREADS=8
+	THREADS=1
 fi
 
 args=("$@")
@@ -35,10 +35,10 @@ DISTOPTVER="--enable-dist-version=${DISTROVERSION}"
 
 source ./make_dist_config.sh
 
-./configure "${DISTOPTNAME}" "${DISTOPTVER}" --target=amiga-m68k --with-optimization="-Os" --enable-ccache --with-aros-prefs=classic --with-resolution=640x256x4 --with-cpu=68020 --with-serial-debug --enable-debug=all $@
+./configure "${DISTOPTNAME}" "${DISTOPTVER}" --target=amiga-m68k --with-optimization="-Os" --enable-ccache --with-aros-prefs=classic --with-resolution=640x256x4 --with-cpu=68040 --with-serial-debug --enable-debug=all $@
 
 make -j${THREADS}
-make -j${THREADS} kernel-amiga-m68k
+make -j${THREADS} kernel
 cat bin/amiga-m68k/gen/boot/aros-amiga-m68k-ext.bin bin/amiga-m68k/gen/boot/aros-amiga-m68k-rom.bin > aros.rom
 ls -lah aros.rom
 

--- a/rom/dos/getvar.c
+++ b/rom/dos/getvar.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2010, The AROS Development Team. All rights reserved.
+    Copyright ï¿½ 1995-2010, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: GetVar - Return the value of a local or global variable.
@@ -101,6 +101,16 @@ static LONG getvar_from(const char *name, const char *volume, STRPTR buffer, LON
         SetIoErr(ERROR_BAD_NUMBER);
 
         return 0;
+    }
+
+    //For programs that supply both GVF_GLOBAL_ONLY and GVF_LOCAL_ONLY
+    //we shall disambiguate to remove both.  This should be closer to AOS behaviour.
+    if( (flags & GVF_GLOBAL_ONLY) && (flags & GVF_LOCAL_ONLY) )
+    {
+    	//The behaviour on AOS3.9 is that only the GLOBAL case is carried out.
+    	//So removing the local flag will produce the same behaviour
+        D( bug("GetVar: GVF_GLOBAL_ONLY and GVF_LOCAL_ONLY specified.  Resorting to GVF_GLOBAL_ONLY\n" ));
+    	flags &= ~( GVF_LOCAL_ONLY );
     }
 
     if (name && buffer)


### PR DESCRIPTION
- Changed the build platform to Ubuntu 20.04:  Ubuntu-Latest will always change and one day (as it has already once) something will change that breaks the build.  At least with a fixed version it should stay the same
- Fixed the local build scripts such as rebuild_rom.sh.   Essentially the optimisation and CPU type has been changed.  The rom should be build with "-Os" because building with "-O2" results in a rom that is too large.
- Changed the behaviour of GetVar() so it behaves like AmigaOS when the application developer mistakenly supplies both GVF_GLOBAL_ONLY and GVF_LOCAL_ONLY.  Only  GVF_GLOBAL_ONLY will be observed by the function.