### PR TITLE
Add VS Code folder to ignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /.externalToolBuilders
 /autom4te.cache
 /.vscode
+/.vs
 
 # Apollo
 /ApolloROM.*


### PR DESCRIPTION
VS Code may use a .vs folder instead of .vscode. This is installation dependent.