### PR TITLE
Fix non working demos using AddInterServer through Disable and removal of delay in Enable.s

### DIFF
--- a/arch/m68k-amiga/exec/enable.S
+++ b/arch/m68k-amiga/exec/enable.S
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2010, The AROS Development Team. All rights reserved.
+    Copyright ï¿½ 1995-2010, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: Enable() - Allow interrupts to occur after Disable().
@@ -72,6 +72,4 @@ AROS_SLIB_ENTRY(Enable,Exec,21):
 	subq.b	#1,%a6@(IDNestCnt)
 	bge.s	0f
 	move.w	#0xc000,0xdff09a
-        tst.b 0xbfe001
-	tst.b 0xbfe001
 0:	rts

--- a/arch/m68k-amiga/timer/lowlevel.c
+++ b/arch/m68k-amiga/timer/lowlevel.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2018, The AROS Development Team. All rights reserved.
+    Copyright ï¿½ 1995-2018, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: CIA timer.device
@@ -264,7 +264,10 @@ AROS_INTH1(cia_vbint, struct TimerBase *, TimerBase)
 		return 0;
 	inc64(&TimerBase->tb_vb_count);
 
-	Disable();
+	/* Disable(); */
+	asm volatile ("move.w #0x4000,0xdff09a\n");
+	/* Disable() / Enable() here interfere with demos using AddInterServer called from Disable() */
+	/* replaced by disabling / enabling Interrupt using INTENA */
     	ForeachNodeSafe(&TimerBase->tb_Lists[UNIT_VBLANK], tr, next) {
 	    	if (cmp64(&TimerBase->tb_vb_count, &tr->tr_time)) {
 	           	Remove((struct Node *)tr);
@@ -280,7 +283,8 @@ AROS_INTH1(cia_vbint, struct TimerBase *, TimerBase)
 	if (IsListEmpty(&TimerBase->tb_Lists[UNIT_VBLANK])) {
 		TimerBase->tb_vblank_on = FALSE;
 	}
-	Enable();
+	/* Enable(); */
+	asm volatile ("move.w #0xc000,0xdff09a\n");
 	
 	return 0;	
 


### PR DESCRIPTION
- Removed of unnecessary delay in Enable.s. This was discussed with Morten and BigGun and declared useless for V4.

- Replaced Disable() / Enable() used in lowlevel.c by move.w #$4000,$dff09a and move.w #$c000,$dff09a. The Interrupt code of timer.device Vblank Interrupt use this code and is in conflict with demos that add their interrupts using AddIntServer which is called when in Disable mode. All demos presents in ApolloOS 9.5.1 in folders Demos.OCS.Issues now run.
